### PR TITLE
Update RNAzureAdal.podspec

### DIFF
--- a/ios/RNAzureAdal.podspec
+++ b/ios/RNAzureAdal.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNAzureAdal
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/Durgaprasad-Budhwani/azure-activedirectory-library-for-react-native"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "durgaprasad.budhwani@gmail.com" }


### PR DESCRIPTION
Add homepage of "https://github.com/Durgaprasad-Budhwani/azure-activedirectory-library-for-react-native"

Having an empty homepage causes an error with `pod install` on newer React Native versions.